### PR TITLE
Quick fix to support dpkg and rpm based distros

### DIFF
--- a/needs-restart.pl
+++ b/needs-restart.pl
@@ -57,7 +57,17 @@ foreach $proc (@procs) {
     my $service = $services_cache{$proc->{pid}};
 
     unless (exists $pkgs_cache{$proc->{file}}) {
-        my $pkg = `rpm -qf $proc->{file} 2>&-`;
+        # Define at outer scope, set within inner if block scope
+        my $pkg = "";
+        if ( -e '/usr/bin/dpkg') {
+            $pkg = `dpkg -S $proc->{file} 2>&-`;
+        }
+        elsif (-e '/usr/bin/rpm') {
+            $pkg = `rpm -qf $proc->{file} 2>&-`;
+        }
+        else {
+            die("Failed to identify distribution specific packaging tool");
+        }
         chomp $pkg;
         $pkgs_cache{$proc->{file}} = $pkg ? $pkg : "";
     }


### PR DESCRIPTION
This commit introduces a check for either dpkg or rpm and uses what is found to perform further tasks. 

I'm not a Perl programmer, so this is likely not up to community standards and can be performed in a more reliable manner.